### PR TITLE
reproduce the typescript error by running "tsc"

### DIFF
--- a/tsconfig.json
+++ b/tsconfig.json
@@ -17,7 +17,9 @@
     "moduleResolution": "node",
     "resolveJsonModule": true,
     "isolatedModules": true,
-    "noEmit": true,
+    // "noEmit": true,
+    "declaration": true,
+    "outDir": "dist",
     "jsx": "react"
   },
   "include": [


### PR DESCRIPTION
To reproduce, please run the following:
1. `bit install`
2. `./node_modules/.bin/tsc`

You should get the following error:
```
src/combobox/index.tsx:4:14 - error TS4023: Exported variable 'ComboBox' has or is using name '_EuiComboBoxProps' from external module "@elastic/eui/src/components/combo_box/combo_box" but cannot be named.

4 export const ComboBox = wrapEuiField({
               ~~~~~~~~


Found 1 error.
```